### PR TITLE
Removed transform to computer name for local Principal

### DIFF
--- a/WmiNamespaceSecurity.psm1
+++ b/WmiNamespaceSecurity.psm1
@@ -126,9 +126,6 @@ class WMINamespaceSecurity {
         if ($this.Ensure -eq [Ensure]::Present) {
             if ($ace -eq $null) {
                 $domain, $user = [WMINamespaceSecurity]::SplitPrincipal($this.Principal)
-                if ($domain -eq [string]::Empty -or $domain -eq "BUILTIN") {
-                    $domain = $env:COMPUTERNAME
-                }
                 $ntuser = New-Object System.Security.Principal.NTAccount($domain,$user)
                 $trustee = New-CimInstance -Namespace root/cimv2 -ClassName Win32_Trustee -ClientOnly -Property @{Domain=$domain;Name=$user;
                     SidString=$ntuser.Translate([System.Security.Principal.SecurityIdentifier]).Value}


### PR DESCRIPTION
The Set() method includes code that transforms the domain
variable to $env:computername when the domain is empty
or when it is "BUILTIN". However, the subsequent calls to
create a NTAccount and translate that account into a SID
fail when the domain is set to $env:computername.

The SID lookup works fine when the domain is set to
empty string, "." or "BUILTIN".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/wminamespacesecurity/3)
<!-- Reviewable:end -->
